### PR TITLE
merge

### DIFF
--- a/src/main/java/site/alice/liveman/mediaproxy/proxytask/MediaProxyTask.java
+++ b/src/main/java/site/alice/liveman/mediaproxy/proxytask/MediaProxyTask.java
@@ -88,7 +88,7 @@ public abstract class MediaProxyTask implements Runnable, Serializable {
     public Image getKeyFrame() {
         String fileName = UUID.randomUUID() + ".jpg";
         String keyFrameCmdLine = FfmpegUtil.buildKeyFrameCmdLine(targetUrl.toString(), fileName);
-        long process = ProcessUtil.createProcess(liveManSetting.getFfmpegPath(), keyFrameCmdLine, false);
+        long process = ProcessUtil.createProcess(liveManSetting.getFfmpegPath(), keyFrameCmdLine, getVideoId() + "_KeyFrame", false);
         if (ProcessUtil.waitProcess(process, 10000)) {
             try {
                 return ImageIO.read(new File(fileName));

--- a/src/main/java/site/alice/liveman/mediaproxy/proxytask/NicoLiveMediaProxyTask.java
+++ b/src/main/java/site/alice/liveman/mediaproxy/proxytask/NicoLiveMediaProxyTask.java
@@ -78,7 +78,6 @@ public class NicoLiveMediaProxyTask extends M3u8MediaProxyTask {
             public void beforeRequest(Map<String, List<String>> headers) {
                 headers.put("Origin", Collections.singletonList("http://live2.nicovideo.jp"));
                 headers.put("User-Agent", Collections.singletonList("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"));
-                headers.put("Cookie", Collections.singletonList(getVideoInfo().getChannelInfo().getCookies()));
             }
         }).build();
         try {

--- a/src/main/java/site/alice/liveman/mediaproxy/proxytask/NicoLiveMediaProxyTask.java
+++ b/src/main/java/site/alice/liveman/mediaproxy/proxytask/NicoLiveMediaProxyTask.java
@@ -78,6 +78,7 @@ public class NicoLiveMediaProxyTask extends M3u8MediaProxyTask {
             public void beforeRequest(Map<String, List<String>> headers) {
                 headers.put("Origin", Collections.singletonList("http://live2.nicovideo.jp"));
                 headers.put("User-Agent", Collections.singletonList("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"));
+                headers.put("Cookie", Collections.singletonList(getVideoInfo().getChannelInfo().getCookies()));
             }
         }).build();
         try {

--- a/src/main/java/site/alice/liveman/mediaproxy/proxytask/TwitcastingMediaProxyTask.java
+++ b/src/main/java/site/alice/liveman/mediaproxy/proxytask/TwitcastingMediaProxyTask.java
@@ -84,7 +84,6 @@ public class TwitcastingMediaProxyTask extends MediaProxyTask {
             public void beforeRequest(Map<String, List<String>> headers) {
                 headers.put("Origin", Collections.singletonList("https://twitcasting.tv"));
                 headers.put("User-Agent", Collections.singletonList("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"));
-                headers.put("Cookie", Collections.singletonList(getVideoInfo().getChannelInfo().getCookies()));
             }
         }).build();
         try {

--- a/src/main/java/site/alice/liveman/mediaproxy/proxytask/TwitcastingMediaProxyTask.java
+++ b/src/main/java/site/alice/liveman/mediaproxy/proxytask/TwitcastingMediaProxyTask.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.Proxy;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -81,7 +82,9 @@ public class TwitcastingMediaProxyTask extends MediaProxyTask {
         ClientEndpointConfig clientEndpointConfig = ClientEndpointConfig.Builder.create().configurator(new ClientEndpointConfig.Configurator() {
             @Override
             public void beforeRequest(Map<String, List<String>> headers) {
-                headers.put("Origin", Arrays.asList("https://twitcasting.tv"));
+                headers.put("Origin", Collections.singletonList("https://twitcasting.tv"));
+                headers.put("User-Agent", Collections.singletonList("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36"));
+                headers.put("Cookie", Collections.singletonList(getVideoInfo().getChannelInfo().getCookies()));
             }
         }).build();
         try {

--- a/src/main/java/site/alice/liveman/model/ChannelInfo.java
+++ b/src/main/java/site/alice/liveman/model/ChannelInfo.java
@@ -31,6 +31,7 @@ public class ChannelInfo implements Serializable {
     private String               dynamicPostAccountId;
     private String               channelUrl;
     private String               channelName;
+    private String               cookies;
     private int[]                defaultArea;
     @JSONField(serialize = false)
     private Long                 startAt;
@@ -91,6 +92,14 @@ public class ChannelInfo implements Serializable {
         } else {
             this.channelUrl = null;
         }
+    }
+
+    public String getCookies() {
+        return cookies;
+    }
+
+    public void setCookies(String cookies) {
+        this.cookies = cookies;
     }
 
     public String getMediaUrl() {

--- a/src/main/java/site/alice/liveman/service/broadcast/BroadcastServiceManager.java
+++ b/src/main/java/site/alice/liveman/service/broadcast/BroadcastServiceManager.java
@@ -238,7 +238,7 @@ public class BroadcastServiceManager implements ApplicationContextAware {
                             VideoInfo currentVideo = broadcastAccount.getCurrentVideo();
                             String broadcastAddress = getBroadcastService(broadcastAccount.getAccountSite()).getBroadcastAddress(broadcastAccount);
                             String ffmpegCmdLine = FfmpegUtil.buildFfmpegCmdLine(currentVideo, broadcastAddress);
-                            pid = ProcessUtil.createProcess(liveManSetting.getFfmpegPath(), ffmpegCmdLine, false);
+                            pid = ProcessUtil.createProcess(liveManSetting.getFfmpegPath(), ffmpegCmdLine, currentVideo.getVideoId(), false);
                             log.info("[" + broadcastAccount.getRoomId() + "@" + broadcastAccount.getAccountSite() + ", videoId=" + currentVideo.getVideoId() + "]推流进程已启动[PID:" + pid + "][" + ffmpegCmdLine.replace("\t", " ") + "]");
                             // 等待进程退出或者任务结束
                             while (broadcastAccount.getCurrentVideo() != null && !ProcessUtil.waitProcess(pid, 1000)) ;
@@ -277,7 +277,7 @@ public class BroadcastServiceManager implements ApplicationContextAware {
                     if (broadcastAccount.getCurrentVideo() == null) {
                         getBroadcastService(broadcastAccount.getAccountSite()).stopBroadcast(broadcastAccount, true);
                     }
-                }, 5, TimeUnit.MINUTES);
+                }, 2, TimeUnit.MINUTES);
                 if (!broadcastAccount.removeCurrentVideo(videoInfo)) {
                     log.error("无法移除账号[" + broadcastAccount.getAccountId() + "]正在转播的节目[" + broadcastAccount.getCurrentVideo().getVideoId() + "]，目标节目与预期节目[" + videoInfo.getVideoId() + "]不符");
                     return false;

--- a/src/main/java/site/alice/liveman/service/broadcast/impl/BilibiliBroadcastService.java
+++ b/src/main/java/site/alice/liveman/service/broadcast/impl/BilibiliBroadcastService.java
@@ -69,7 +69,9 @@ public class BilibiliBroadcastService implements BroadcastService {
     public String getBroadcastAddress(AccountInfo accountInfo) throws Exception {
         VideoInfo videoInfo = accountInfo.getCurrentVideo();
         int area = 199;
-        if (videoInfo.getArea() != null) {
+        if (videoInfo.isVideoBanned()) {
+            area = 33;
+        } else if (videoInfo.getArea() != null) {
             area = videoInfo.getArea()[1];
         }
         if (accountInfo.isAutoRoomTitle()) {

--- a/src/main/java/site/alice/liveman/service/live/impl/AbemaLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/AbemaLiveService.java
@@ -40,10 +40,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -111,7 +108,7 @@ public class AbemaLiveService extends LiveService {
             String slotId = matcher.group(2);
             Map<String, String> requestProperties = new HashMap<>();
             requestProperties.put("Authorization", "bearer " + bearer);
-            String slotInfo = HttpRequestUtil.downloadUrl(new URI("https://api.abema.io/v1/media/slots/" + slotId), null, requestProperties, StandardCharsets.UTF_8);
+            String slotInfo = HttpRequestUtil.downloadUrl(new URI("https://api.abema.io/v1/media/slots/" + slotId), channelInfo.getCookies(), requestProperties, StandardCharsets.UTF_8);
             JSONObject slotInfoObj = JSON.parseObject(slotInfo);
             String seriesId = slotInfoObj.getJSONObject("slot").getJSONArray("programs").getJSONObject(0).getJSONObject("series").getString("id");
             Calendar japanCalendar = Calendar.getInstance(TimeZone.getTimeZone("JST"));
@@ -119,7 +116,7 @@ public class AbemaLiveService extends LiveService {
             dateFormat.setCalendar(japanCalendar);
             long currentTimeMillis = System.currentTimeMillis();
             String formattedDate = dateFormat.format(currentTimeMillis);
-            String timetableInfo = HttpRequestUtil.downloadUrl(new URI(String.format("https://api.abema.io/v1/media?dateFrom=%s&dateTo=%s&channelIds=%s", formattedDate, formattedDate, channelId)), null, requestProperties, StandardCharsets.UTF_8);
+            String timetableInfo = HttpRequestUtil.downloadUrl(new URI(String.format("https://api.abema.io/v1/media?dateFrom=%s&dateTo=%s&channelIds=%s", formattedDate, formattedDate, channelId)), channelInfo.getCookies(), requestProperties, StandardCharsets.UTF_8);
             JSONArray channelSchedules = JSON.parseObject(timetableInfo).getJSONArray("channelSchedules");
             if (channelSchedules.isEmpty()) {
                 return null;
@@ -150,19 +147,19 @@ public class AbemaLiveService extends LiveService {
         String channelId = videoInfoUrl.toString().substring(NOW_ON_AIR_URL.length());
         Map<String, String> requestProperties = new HashMap<>();
         requestProperties.put("Authorization", "bearer " + bearer);
-        String tokenJSON = HttpRequestUtil.downloadUrl(new URI("https://api.abema.io/v1/media/token?osName=pc&osVersion=1.0.0&osLang=&osTimezone=&appVersion=v18.1204.3"), null, requestProperties, StandardCharsets.UTF_8);
+        String tokenJSON = HttpRequestUtil.downloadUrl(new URI("https://api.abema.io/v1/media/token?osName=pc&osVersion=1.0.0&osLang=&osTimezone=&appVersion=v18.1204.3"), channelInfo.getCookies(), requestProperties, StandardCharsets.UTF_8);
         String token = JSON.parseObject(tokenJSON).getString("token");
         long kg = getKeyGenerator();
         String mediaUrl = "https://ds-linear-abematv.akamaized.net/channel/" + channelId + "/" + liveManSetting.getDefaultResolution() + "/playlist.m3u8?ccf=26&kg=" + kg;
-        String m3u8File = HttpRequestUtil.downloadUrl(new URI(mediaUrl), StandardCharsets.UTF_8);
+        String m3u8File = HttpRequestUtil.downloadUrl(new URI(mediaUrl), channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         Matcher keyMatcher = m3u8KeyPattern.matcher(m3u8File);
         if (keyMatcher.find()) {
             String lt = keyMatcher.group(2);
             byte[] iv = Hex.decodeHex(keyMatcher.group(3));
-            String licenseJson = HttpRequestUtil.downloadUrl(new URI("https://license.abema.io/abematv-hls?t=" + token), null, "{\"lt\":\"" + lt + "\",\"kv\":\"wd\",\"kg\":" + kg + "}", StandardCharsets.UTF_8);
+            String licenseJson = HttpRequestUtil.downloadUrl(new URI("https://license.abema.io/abematv-hls?t=" + token), channelInfo.getCookies(), "{\"lt\":\"" + lt + "\",\"kv\":\"wd\",\"kg\":" + kg + "}", StandardCharsets.UTF_8);
             String cid = JSON.parseObject(licenseJson).getString("cid");
             String k = JSON.parseObject(licenseJson).getString("k");
-            String slotsJson = HttpRequestUtil.downloadUrl(new URI("https://api.abema.io/v1/broadcast/slots/" + cid), StandardCharsets.UTF_8);
+            String slotsJson = HttpRequestUtil.downloadUrl(new URI("https://api.abema.io/v1/broadcast/slots/" + cid), channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
             JSONObject slotsObj = JSON.parseObject(slotsJson).getJSONObject("slot");
             VideoInfo videoInfo = new VideoInfo(channelInfo, cid, slotsObj.getString("title"), new URI(mediaUrl), "m3u8");
             videoInfo.setEncodeMethod(keyMatcher.group(1));

--- a/src/main/java/site/alice/liveman/service/live/impl/MirrativLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/MirrativLiveService.java
@@ -29,6 +29,7 @@ import site.alice.liveman.utils.HttpRequestUtil;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 @Service
 public class MirrativLiveService extends LiveService {
@@ -40,7 +41,7 @@ public class MirrativLiveService extends LiveService {
         String channelUrl = channelInfo.getChannelUrl();
         String userId = channelUrl.replace("https://www.mirrativ.com/user/", "").replace("/", "");
         URI liveHistoryUrl = new URI("https://www.mirrativ.com/api/live/live_history?user_id=" + userId + "&page=1");
-        String liveHistoryJson = HttpRequestUtil.downloadUrl(liveHistoryUrl, StandardCharsets.UTF_8);
+        String liveHistoryJson = HttpRequestUtil.downloadUrl(liveHistoryUrl, channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         JSONObject liveHistory = JSON.parseObject(liveHistoryJson);
         JSONArray lives = liveHistory.getJSONArray("lives");
         if (!lives.isEmpty()) {
@@ -59,7 +60,7 @@ public class MirrativLiveService extends LiveService {
             return null;
         }
         String videoId = videoInfoUrl.toString().substring(GET_LIVE_INFO_URL.length());
-        String liveDetailJson = HttpRequestUtil.downloadUrl(new URI("https://www.mirrativ.com/api/live/live?live_id=" + videoId), StandardCharsets.UTF_8);
+        String liveDetailJson = HttpRequestUtil.downloadUrl(new URI("https://www.mirrativ.com/api/live/live?live_id=" + videoId), channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         JSONObject liveDetailObj = JSON.parseObject(liveDetailJson);
         String videoTitle = liveDetailObj.getString("title");
         URI m3u8ListUrl = new URI(liveDetailObj.getString("streaming_url_hls"));

--- a/src/main/java/site/alice/liveman/service/live/impl/NicoLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/NicoLiveService.java
@@ -26,6 +26,7 @@ import site.alice.liveman.utils.HttpRequestUtil;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,7 +45,7 @@ public class NicoLiveService extends LiveService {
         if (!channelUrl.endsWith("/live")) {
             channelUrl += "/live";
         }
-        String html = HttpRequestUtil.downloadUrl(new URI(channelUrl), StandardCharsets.UTF_8);
+        String html = HttpRequestUtil.downloadUrl(new URI(channelUrl), channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         Matcher matcher = LIVE_VIDEO_URL_PATTERN.matcher(html);
         if (matcher.find()) {
             return new URI(matcher.group(1));
@@ -57,7 +58,7 @@ public class NicoLiveService extends LiveService {
         if (videoInfoUrl == null) {
             return null;
         }
-        String html = HttpRequestUtil.downloadUrl(videoInfoUrl, StandardCharsets.UTF_8);
+        String html = HttpRequestUtil.downloadUrl(videoInfoUrl, channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         Matcher matcher = EMBEDDED_DATA_PATTERN.matcher(html);
         if (matcher.find()) {
             String embeddedData = matcher.group(1);

--- a/src/main/java/site/alice/liveman/service/live/impl/OpenRecLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/OpenRecLiveService.java
@@ -30,6 +30,7 @@ import site.alice.liveman.utils.HttpRequestUtil;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 @Service
 public class OpenRecLiveService extends LiveService {
@@ -43,7 +44,7 @@ public class OpenRecLiveService extends LiveService {
     public URI getLiveVideoInfoUrl(ChannelInfo channelInfo) throws Exception {
         String channelName = channelInfo.getChannelUrl().replace("https://www.openrec.tv/user/", "");
         URI moviesUrl = new URI(GET_MOVIES_API + "?channel_id=" + channelName + "&sort=onair_status");
-        String moviesJson = HttpRequestUtil.downloadUrl(moviesUrl, StandardCharsets.UTF_8);
+        String moviesJson = HttpRequestUtil.downloadUrl(moviesUrl, channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         JSONArray movies = JSON.parseArray(moviesJson);
         if (!movies.isEmpty()) {
             JSONObject movieObj = (JSONObject) movies.get(0);
@@ -62,7 +63,7 @@ public class OpenRecLiveService extends LiveService {
             return null;
         }
         String videoId = videoInfoUrl.toString().substring(GET_VIDEO_INFO_URL.length());
-        String movieObjJson = HttpRequestUtil.downloadUrl(new URI(GET_MOVIES_API + "/" + videoId), StandardCharsets.UTF_8);
+        String movieObjJson = HttpRequestUtil.downloadUrl(new URI(GET_MOVIES_API + "/" + videoId), channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         JSONObject movieObj = JSON.parseObject(movieObjJson);
         String videoTitle = movieObj.getString("title");
         URI m3u8ListUrl = new URI(movieObj.getJSONObject("media").getString("url"));

--- a/src/main/java/site/alice/liveman/service/live/impl/PscpLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/PscpLiveService.java
@@ -1,0 +1,84 @@
+/*
+ * <Alice LiveMan>
+ * Copyright (C) <2018>  <NekoSunflower>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package site.alice.liveman.service.live.impl;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Service;
+import site.alice.liveman.model.ChannelInfo;
+import site.alice.liveman.model.VideoInfo;
+import site.alice.liveman.service.live.LiveService;
+import site.alice.liveman.utils.HttpRequestUtil;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class PscpLiveService extends LiveService {
+
+    private static final Pattern dataStorePattern     = Pattern.compile("data-store=\"(.+?)\">");
+    private static final String  LIVE_VIDEO_URL       = "https://www.pscp.tv/w/";
+    private static final String  accessVideoPublicUrl = "https://proxsee.pscp.tv/api/v2/accessVideoPublic?broadcast_id=";
+
+    @Override
+    public URI getLiveVideoInfoUrl(ChannelInfo channelInfo) throws Exception {
+        String channelUrl = channelInfo.getChannelUrl();
+        String channelHtml = HttpRequestUtil.downloadUrl(new URI(channelUrl), channelInfo.getChannelUrl(), Collections.emptyMap(), StandardCharsets.UTF_8);
+        Matcher dataStoreMatcher = dataStorePattern.matcher(channelHtml);
+        if (dataStoreMatcher.find()) {
+            String dataStore = StringEscapeUtils.unescapeJava(dataStoreMatcher.group(0));
+            JSONObject dataStoreObj = JSON.parseObject(dataStore);
+            JSONObject broadcasts = dataStoreObj.getJSONObject("BroadcastCache").getJSONObject("broadcasts");
+            for (String videoId : broadcasts.keySet()) {
+                JSONObject broadcastObj = broadcasts.getJSONObject(videoId);
+                String state = broadcastObj.getJSONObject("broadcast").getString("state");
+                if ("RUNNING".equals(state)) {
+                    return new URI(LIVE_VIDEO_URL + videoId);
+                }
+            }
+        } else {
+            throw new RuntimeException("没有找到DataStore[" + channelUrl + "]");
+        }
+        return null;
+    }
+
+    @Override
+    public VideoInfo getLiveVideoInfo(URI videoInfoUrl, ChannelInfo channelInfo) throws Exception {
+        String broadcastId = videoInfoUrl.getPath().replace("/w/", "");
+        String json = HttpRequestUtil.downloadUrl(new URI(accessVideoPublicUrl + broadcastId), channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
+        JSONObject accessVideoPublic = JSON.parseObject(json);
+        JSONObject broadcast = accessVideoPublic.getJSONObject("broadcast");
+        String title = broadcast.getString("status");
+        String hlsUrl = accessVideoPublic.getString("hls_url");
+        if (StringUtils.isNotEmpty(hlsUrl)) {
+            return new VideoInfo(channelInfo, broadcastId, title, new URI(hlsUrl), "m3u8");
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean isMatch(URI channelUrl) {
+        return channelUrl.getHost().contains("pscp.tv");
+    }
+}

--- a/src/main/java/site/alice/liveman/service/live/impl/ShowRoomLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/ShowRoomLiveService.java
@@ -30,6 +30,7 @@ import site.alice.liveman.utils.HttpRequestUtil;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,7 +51,7 @@ public class ShowRoomLiveService extends LiveService {
         if (videoInfoUrl == null) {
             return null;
         }
-        String channelHtml = HttpRequestUtil.downloadUrl(videoInfoUrl, StandardCharsets.UTF_8);
+        String channelHtml = HttpRequestUtil.downloadUrl(videoInfoUrl, channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         Matcher matcher = initDataPattern.matcher(channelHtml);
         if (matcher.find()) {
             JSONObject liveDataObj = JSON.parseObject(StringEscapeUtils.unescapeHtml(matcher.group(1)));

--- a/src/main/java/site/alice/liveman/service/live/impl/TwitcastingLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/TwitcastingLiveService.java
@@ -30,6 +30,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,24 +52,24 @@ public class TwitcastingLiveService extends LiveService {
         }
         String roomName = videoInfoUrl.toString().replace("https://twitcasting.tv/", "").replace("/", "");
         URI streamCheckerUrl = new URI("https://twitcasting.tv/streamchecker.php?u=" + roomName + "&v=999&myself=&islive=1&lastitemid=-1&__c=" + System.currentTimeMillis());
-        String streamChecker = HttpRequestUtil.downloadUrl(streamCheckerUrl, StandardCharsets.UTF_8);
+        String streamChecker = HttpRequestUtil.downloadUrl(streamCheckerUrl, channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
         String[] checkes = streamChecker.split("\t");
         Video video = parseVideo(checkes[0], Integer.parseInt(checkes[1]), checkes[7], Integer.parseInt(checkes[19].trim()));
         if (!video.getOnline()) {
             return null;
         }
         if (video.getPrivate()) {
-            log.warn("频道[" + channelInfo.getChannelName() + "]正在直播的内容已加密，无法转播！");
+            log.warn("频道[" + channelInfo.getChannelName() + "]正在直播的内容已加密！");
         }
         if (video.getWatchable()) {
             URI streamServerUrl = new URI("https://twitcasting.tv/streamserver.php?target=" + roomName + "&mode=client");
-            String serverInfo = HttpRequestUtil.downloadUrl(streamServerUrl, StandardCharsets.UTF_8);
+            String serverInfo = HttpRequestUtil.downloadUrl(streamServerUrl, channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
 
             JSONObject streamServer = JSONObject.parseObject(serverInfo);
             JSONObject movie = streamServer.getJSONObject("movie");
             if (movie.getBoolean("live")) {
                 String videoTitle = "";
-                String roomHtml = HttpRequestUtil.downloadUrl(videoInfoUrl, StandardCharsets.UTF_8);
+                String roomHtml = HttpRequestUtil.downloadUrl(videoInfoUrl, channelInfo.getCookies(), Collections.emptyMap(), StandardCharsets.UTF_8);
                 Matcher matcher = ROOM_TITLE_PATTERN.matcher(roomHtml);
                 if (matcher.find()) {
                     videoTitle = matcher.group(1);

--- a/src/main/java/site/alice/liveman/service/live/impl/TwitchLiveService.java
+++ b/src/main/java/site/alice/liveman/service/live/impl/TwitchLiveService.java
@@ -57,13 +57,13 @@ public class TwitchLiveService extends LiveService {
         String channelName = channelUrl.substring(22);
         Map<String, String> headerMap = new HashMap<>();
         headerMap.put("client-id", clientId);
-        String streamJSON = HttpRequestUtil.downloadUrl(new URI(GET_STREAM_INFO_URL + channelName), null, headerMap, StandardCharsets.UTF_8);
+        String streamJSON = HttpRequestUtil.downloadUrl(new URI(GET_STREAM_INFO_URL + channelName), channelInfo.getCookies(), headerMap, StandardCharsets.UTF_8);
         JSONObject streamObj = JSON.parseObject(streamJSON).getJSONObject("stream");
         if (streamObj != null) {
             String videoId = streamObj.getString("_id");
             JSONObject channelObj = streamObj.getJSONObject("channel");
             String videoTitle = channelObj.getString("status");
-            String streamTokenJSON = HttpRequestUtil.downloadUrl(new URI(String.format(GET_STREAM_TOKEN_URL, channelName)), null, headerMap, StandardCharsets.UTF_8);
+            String streamTokenJSON = HttpRequestUtil.downloadUrl(new URI(String.format(GET_STREAM_TOKEN_URL, channelName)), channelInfo.getCookies(), headerMap, StandardCharsets.UTF_8);
             JSONObject streamTokenObj = JSON.parseObject(streamTokenJSON);
             String token = streamTokenObj.getString("token");
             String sig = streamTokenObj.getString("sig");
@@ -104,7 +104,7 @@ public class TwitchLiveService extends LiveService {
         String channelName = channelUrl.substring(22);
         Map<String, String> headerMap = new HashMap<>();
         headerMap.put("client-id", clientId);
-        String streamJSON = HttpRequestUtil.downloadUrl(new URI(GET_STREAM_INFO_URL + channelName), null, headerMap, StandardCharsets.UTF_8);
+        String streamJSON = HttpRequestUtil.downloadUrl(new URI(GET_STREAM_INFO_URL + channelName), channelInfo.getCookies(), headerMap, StandardCharsets.UTF_8);
         JSONObject streamObj = JSON.parseObject(streamJSON).getJSONObject("stream");
         if (streamObj != null && "live".equals(streamObj.getString("stream_type"))) {
             return new URI(channelUrl);

--- a/src/main/java/site/alice/liveman/utils/FfmpegUtil.java
+++ b/src/main/java/site/alice/liveman/utils/FfmpegUtil.java
@@ -55,7 +55,7 @@ public class FfmpegUtil {
     }
 
     public static String buildFfmpegCmdLine(VideoInfo videoInfo, String broadcastAddress) {
-        String loopCmdLine = "\t-i\t\"" + videoInfo.getChannelInfo().getMediaUrl() + "\"";
+        String loopCmdLine = "\t-re\t-i\t\"" + videoInfo.getChannelInfo().getMediaUrl() + "\"";
         if (videoInfo.isAudioBanned()) {
             loopCmdLine += "\t-ac\t1";
         }

--- a/src/main/java/site/alice/liveman/videofilter/BiliBannedKeywordFilter.java
+++ b/src/main/java/site/alice/liveman/videofilter/BiliBannedKeywordFilter.java
@@ -48,9 +48,11 @@ public class BiliBannedKeywordFilter implements VideoFilter {
             }
         }
         for (String _bannedKeyword : liveManSetting.getBannedKeywords()) {
-            if (StringUtils.containsIgnoreCase(videoInfo.getTitle(), _bannedKeyword) || _bannedKeyword.equals(bannedKeyword)) {
-                bannedKeyword = _bannedKeyword;
-                break;
+            if (StringUtils.isNotEmpty(_bannedKeyword)) {
+                if (StringUtils.containsIgnoreCase(videoInfo.getTitle(), _bannedKeyword) || _bannedKeyword.equals(bannedKeyword)) {
+                    bannedKeyword = _bannedKeyword;
+                    break;
+                }
             }
         }
         if (bannedKeyword == null) {

--- a/src/main/java/site/alice/liveman/web/rpc/BroadcastController.java
+++ b/src/main/java/site/alice/liveman/web/rpc/BroadcastController.java
@@ -156,10 +156,13 @@ public class BroadcastController {
     }
 
     @RequestMapping("/createTask.json")
-    public ActionResult createTask(String videoUrl) {
+    public ActionResult createTask(String videoUrl, String cookies) {
         AccountInfo account = (AccountInfo) session.getAttribute("account");
         try {
-            VideoInfo liveVideoInfo = liveServiceFactory.getLiveService(videoUrl).getLiveVideoInfo(new URI(videoUrl), null);
+            ChannelInfo channelInfo = new ChannelInfo();
+            channelInfo.setChannelName("手动推流");
+            channelInfo.setCookies(cookies);
+            VideoInfo liveVideoInfo = liveServiceFactory.getLiveService(videoUrl).getLiveVideoInfo(new URI(videoUrl), channelInfo);
             if (liveVideoInfo == null) {
                 return ActionResult.getErrorResult("当前节目尚未开播");
             }

--- a/src/main/java/site/alice/liveman/web/rpc/ChannelController.java
+++ b/src/main/java/site/alice/liveman/web/rpc/ChannelController.java
@@ -20,6 +20,7 @@ package site.alice.liveman.web.rpc;
 
 import com.alibaba.fastjson.JSON;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
@@ -105,6 +106,9 @@ public class ChannelController {
                 channel.setDynamicPostAccountId(channelInfo.getDynamicPostAccountId());
                 channel.setAutoBalance(channelInfo.isAutoBalance());
                 channel.setDefaultArea(channelInfo.getDefaultArea());
+                if (!StringUtils.isEmpty(channelInfo.getCookies())) {
+                    channel.setCookies(channelInfo.getCookies());
+                }
                 try {
                     settingConfig.saveSetting(liveManSetting);
                 } catch (Exception e) {


### PR DESCRIPTION
1.LiveService - 支持带Cookies转播  …
2.LiveService - 支持pscp.tv直播网站
3.LiveService - 每隔1小时自动刷新Reality用户列表
4.LiveService - 修复当Youtube节目断流时，主播重新链接无法继续转播的问题
5.BilibiliBroadcastService - 如果视频打了马赛克，自动切换到映评馆直播
6.FFMPEG - 修复在某些特殊情况下B站直播间视频出现鬼畜的问题
7.FFMPEG - 单独保存每个转播任务的ffmpeg日志，方便问题排查